### PR TITLE
Make runner test tests using the ClassData, MemberData attributes

### DIFF
--- a/Assets/Scripts/EntryPoint.cs
+++ b/Assets/Scripts/EntryPoint.cs
@@ -145,6 +145,7 @@ public class EntryPoint : MonoBehaviour
                     ITestFrameworkDiscoveryOptions discoveryOptions =
                         TestFrameworkOptions.ForDiscovery(configuration);
                     discoveryOptions.SetSynchronousMessageReporting(true);
+                    discoveryOptions.SetPreEnumerateTheories(false);
                     controller.Find(false, messageSink, discoveryOptions);
                     messageSink.DiscoveryCompletionWaitHandle.WaitOne();
                     ITestCase[] testCases =


### PR DESCRIPTION
Before this, this runner couldn't test tests using the ClassData, MemberData attributes.
But, since I set PreEnumerateTheories flag to false, it has been able to test them.

See the reference for the option, [TestFrameworkOptionsReadWriteExtensions#SetPreEnumerateTheories](https://github.com/xunit/xunit/blob/master/src/xunit.runner.utility/Extensions/TestFrameworkOptionsReadWriteExtensions.cs#L157)