### PR TITLE
Rename main method to avoid unexpected invocation

### DIFF
--- a/Assets/Scripts/EntryPoint.cs
+++ b/Assets/Scripts/EntryPoint.cs
@@ -71,14 +71,14 @@ public class EntryPoint : MonoBehaviour
             return;
         }
 
-        int? exitCode = Main();
+        int? exitCode = RunTests();
         if (exitCode is int code)
         {
             Application.Quit(code);
         }
     }
 
-    int? Main()
+    int? RunTests()
     {
         string[] commandLineArgs = Environment.GetCommandLineArgs();
         string programName = Path.GetFileName(commandLineArgs[0]);


### PR DESCRIPTION
This PR renames `EntryPoint.Main()` to `EntryPoint.RunTests()` to avoid unexpected invocation.