### PR TITLE
Replace deprecated action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - '*'
+    - '*'
 
 name: push
 jobs:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,8 @@
-on: push
+on:
+  push:
+    tags:
+      - '*'
+
 name: push
 jobs:
   build:
@@ -12,10 +16,6 @@ jobs:
         ULF: ${{ secrets.ULF }}
       with:
         entrypoint: ./build.sh
-    - name: tag-filter
-      uses: actions/bin/filter@master
-      with:
-        args: tag
     - name: release
       uses: docker://alpine:3.9
       env:


### PR DESCRIPTION
Since [Github Actions] announced v2, Some actions including *actions/bin* were deprecated.
So in this pull request, it replaces *actions/bin/filter* action with *on.push.tags*, one among [*Github Actions Workflow* syntax][workflow-syntax].

[Github Actions]: https://github.com/features/actions
[workflow-syntax]: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions